### PR TITLE
Added displayable grid CSS class configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     },
     "./config": {
       "sass": "./src/sass/lib/config.scss"
+    },
+    "./utility": {
+      "sass": "./src/sass/utility/_utility.scss"
     }
   },
   "scripts": {

--- a/src/sass/_index.scss
+++ b/src/sass/_index.scss
@@ -1,3 +1,2 @@
 @use "base/reset";
 @use "config/config";
-@use "utility/utility";

--- a/src/sass/config/_grid.scss
+++ b/src/sass/config/_grid.scss
@@ -7,6 +7,8 @@ $config: (
   "width": 1200,
   // Base grid-size (without units but based on pixels)
   "gutter_size": 24, // Base gutter-size (without units but based on pixels)
+  // The target CSS class used to display the grid background helper
+  "css_class": 'grid',
 );
 
 @include config.merge("grid", $config);

--- a/src/sass/utility/_grid.scss
+++ b/src/sass/utility/_grid.scss
@@ -1,5 +1,8 @@
+@use "../lib/config";
 @use "../tools/tools" as *;
 
-.grid {
-  @include grid();
+@if config.get("grid.css_class") {
+  .#{config.get("grid.css_class")} {
+    @include grid();
+  }
 }

--- a/src/stubs/sass/app.scss
+++ b/src/stubs/sass/app.scss
@@ -1,6 +1,7 @@
 // Keep order
 @use "@whitecube/jean-sass";
 @use "./config/config";
+@use "@whitecube/jean-sass/utility";
 @use "./base/base";
 @use "./parts/parts";
 

--- a/src/stubs/sass/config/_grid.scss
+++ b/src/stubs/sass/config/_grid.scss
@@ -4,6 +4,7 @@
 //     'columns': 12, // Number of columns you want in the grid
 //     'width': 1200, // Base grid-size (without units but based on pixels)
 //     'gutter_size': 24, // Base gutter-size (without units but based on pixels)
+//     'css_class': 'grid', // The target CSS class used to display the grid background helper
 // );
 
 // @include config.merge('grid', $config);


### PR DESCRIPTION
When using `.grid` as a BEM base for a component, this package's grid utility helper automatically kicks in. This is of course not expected behavior for production environments.

This PR adds a `grid.css_class` configuration, which makes it possible to change the default "grid" utility CSS class helper in order to avoid CSS class collisions with the project itself.

Furthermore, this PR also fixes the displayed grid, which was not using the project's configuration (because the utility files were included using `@use` before the project's configuration in `app.scss`).