### PR TITLE
Updated color functions and RGBA usage

### DIFF
--- a/src/sass/tools/_tools.scss
+++ b/src/sass/tools/_tools.scss
@@ -29,6 +29,7 @@
 @forward "mixins/clearfix";
 @forward "mixins/clickableTransparentBg";
 @forward "mixins/cover";
+@forward "mixins/create-css-var-colors";
 @forward "mixins/create-css-var-responsive";
 @forward "mixins/create-css-var";
 @forward "mixins/font-face";

--- a/src/sass/tools/functions/_color.scss
+++ b/src/sass/tools/functions/_color.scss
@@ -10,34 +10,31 @@
 @use "./str-split" as *;
 @use "../../lib/config";
 
-@function color-hex-to-rgb-values($hex) {
+@function color-to-rgb-values($hex) {
   @return color.channel($hex, "red", $space: rgb), color.channel($hex, "green", $space: rgb), color.channel($hex, "blue", $space: rgb);
 }
 
-@function color-namespace($key) {
-  $keys: str-split($key, ".");
-  @return list.join(("colors"), $keys);
-}
+@function color-var($key, $fallback: false) {
+  $namespace: list.join(("colors"), str-split($key, "."));
 
-@function color-var($namespace, $fallback) {
+  @if $fallback == false {
+    @return var(--#{list-concat($namespace, "-")});
+  } 
+
   @return var(
     --#{list-concat($namespace, "-")},
     $fallback
   );
 }
 
-@function color($key) {
-  $namespace: color-namespace($key);
-  $fallback: color-hex-to-rgb-values(config.get(list-concat($namespace, ".")));
-  @return rgb(color-var($namespace, #{$fallback}));
-}
+@function color($key, $opacity: false, $fallback: false) {
+  @if $opacity == false or $opacity >= 1 {
+    @return rgb(color-var($key, $fallback));
+  }
 
-@function color-rgb($key) {
-  @return color($key);
-}
-
-@function color-rgba($key, $opacity) {
-  $namespace: color-namespace($key);
-  $fallback: color-hex-to-rgb-values(config.get(list-concat($namespace, ".")));
-  @return rgba(color-var($namespace, $fallback), $opacity);
+  @if $opacity <= 0 {
+    @return transparent;
+  }
+  
+  @return rgba(color-var($key, $fallback), $opacity);
 }

--- a/src/sass/tools/functions/_color.scss
+++ b/src/sass/tools/functions/_color.scss
@@ -3,10 +3,8 @@
 // returns the defined color in given or default color palette
 // **********************************************************
 
-@use "sass:map";
 @use "sass:list";
 @use "sass:color";
-@use "sass:string";
 @use "./list-concat" as *;
 @use "./str-split" as *;
 @use "../../lib/config";

--- a/src/sass/tools/functions/_color.scss
+++ b/src/sass/tools/functions/_color.scss
@@ -5,20 +5,39 @@
 
 @use "sass:map";
 @use "sass:list";
+@use "sass:color";
 @use "./list-concat" as *;
 @use "./str-split" as *;
 @use "../../lib/config";
 
-@function color($keys...) {
-  $mapped-keys: ("colors");
+@function color-hex-to-rgb-values($hex) {
+  @return color.channel($hex, "red", $space: rgb), color.channel($hex, "green", $space: rgb), color.channel($hex, "blue", $space: rgb);
+}
 
-  @each $key in $keys {
-    $key: str-split($key, ".");
-    $mapped-keys: list.join($mapped-keys, $key);
-  }
+@function color-namespace($key) {
+  $keys: str-split($key, ".");
+  @return list.join(("colors"), $keys);
+}
 
+@function color-var($namespace, $fallback) {
   @return var(
-    --#{list-concat($mapped-keys, "-")},
-    config.get(list-concat($mapped-keys, "."))
+    --#{list-concat($namespace, "-")},
+    $fallback
   );
+}
+
+@function color($key) {
+  $namespace: color-namespace($key);
+  $fallback: color-hex-to-rgb-values(config.get(list-concat($namespace, ".")));
+  @return rgb(color-var($namespace, #{$fallback}));
+}
+
+@function color-rgb($key) {
+  @return color($key);
+}
+
+@function color-rgba($key, $opacity) {
+  $namespace: color-namespace($key);
+  $fallback: color-hex-to-rgb-values(config.get(list-concat($namespace, ".")));
+  @return rgba(color-var($namespace, $fallback), $opacity);
 }

--- a/src/sass/tools/functions/_color.scss
+++ b/src/sass/tools/functions/_color.scss
@@ -6,6 +6,7 @@
 @use "sass:map";
 @use "sass:list";
 @use "sass:color";
+@use "sass:string";
 @use "./list-concat" as *;
 @use "./str-split" as *;
 @use "../../lib/config";
@@ -19,11 +20,11 @@
 
   @if $fallback == false {
     @return var(--#{list-concat($namespace, "-")});
-  } 
+  }
 
   @return var(
     --#{list-concat($namespace, "-")},
-    $fallback
+    color-to-rgb-values($fallback)
   );
 }
 

--- a/src/sass/tools/mixins/_create-css-var-colors.scss
+++ b/src/sass/tools/mixins/_create-css-var-colors.scss
@@ -8,6 +8,6 @@
       @include create-css-var-colors("#{$base}-#{$name}", $config-item);
     }
   } @else {
-    @include create-css-var("#{$base}", color-hex-to-rgb-values($config));
+    @include create-css-var("#{$base}", color-to-rgb-values($config));
   }
 }

--- a/src/sass/tools/mixins/_create-css-var-colors.scss
+++ b/src/sass/tools/mixins/_create-css-var-colors.scss
@@ -1,0 +1,13 @@
+@use "sass:meta";
+@use "../functions/color" as *;
+@use "create-css-var" as *;
+
+@mixin create-css-var-colors($base, $config) {
+  @if meta.type-of($config) == "map" {
+    @each $name, $config-item in $config {
+      @include create-css-var-colors("#{$base}-#{$name}", $config-item);
+    }
+  } @else {
+    @include create-css-var("#{$base}", color-hex-to-rgb-values($config));
+  }
+}

--- a/src/stubs/sass/base/_css-vars.scss
+++ b/src/stubs/sass/base/_css-vars.scss
@@ -2,8 +2,7 @@
 @use "@whitecube/jean-sass/lib/config";
 
 :root {
-  // Will create --colors-key1-key2 type of css variables
-  @include create-css-var("colors", config.get("colors"));
+  @include create-css-var-colors("colors", config.get("colors"));
   @include create-css-var-responsive("radius", config.get("radius"), "rem");
   @include create-css-var-responsive(
     "fs",

--- a/src/stubs/sass/config/_colors.scss
+++ b/src/stubs/sass/config/_colors.scss
@@ -1,4 +1,5 @@
 // @use '@whitecube/jean-sass/config';
+
 // $config: (
 //     'grey': (
 //         '000': #ffffff,
@@ -13,8 +14,6 @@
 //         '800': #646d74,
 //         '900': #3b3f44,
 //         '950': #1b1d1f,
-//         'grey-alpha': rgba(#ffa648, 0.4),
-//         'white-alpha': rgba(#ffffff, 0.4),
 //     ),
 //     'alert': (
 //         'red': #ff1a1a,


### PR DESCRIPTION
**What changed:**

- The generated CSS vars now contain "raw RGB" values instead of HEX colors (ex: `--colors-shade-100: 255, 255, 255` instead of `--colors-shade-100: #ffffff`)
- The `color` function's signature has been updated from `color($keys...)` to `color($key, $opacity: false, $fallback: false)`. Its overall backwards compatibility is assured except for one edge case: it is no longer possible to reference a color by using comma-separated keys. For instance, `color('shade','100')` will no longer work, one should now always use `color('shade.100')` instead (but I don't think the comma-separated syntax was ever used at Whitecube).
- The `color` function's return value has also been updated:
    1. `color('shade.100')` now outputs `rgb(var(--colors-shade-100))` instead of `var(--color-shade-000, #ffffff)`. Notice we don't have automatic fallback values anymore, IMO this was not necessary because these CSS variables are always supposed to be defined using this framework. This is making room for controlled fallback values (see points 5 & 6 below).
    2. `color('shade.100', 0.5)` allows to output `rgba(var(--colors-shade-100),.5)`. When passing an `$opacity` value between 0 and 1, we'll automatically switch the output to `rgba`. This is made possible thanks to usage of raw RGB values in the CSS variables. This way we don't need to declare RGBA-specific variables.
    3. `color('shade.100', 0)` will output `transparent`.
    4. `color('shade.100', 1)` will have the same output as `color('shade.100')` (values for `$opacity` >= 1 will be ignored, switching back to a RGB value).
    5. `color('shade.100', $fallback: #f1f1f1)` will output `rgb(var(--colors-shade-100, 241, 241 ,241))`, which is a valid CSS-variable fallback value.
    6. Of course, all 3 arguments can be used at the same time: `color('shade.100', 0.5, #f1f1f1)` will output `rgba(var(--colors-shade-100, 241, 241, 241),.5)`
- The previous `var()` return value can still be generated using the new `color-var($key, $fallback: false)` function. Remember it will however always return raw RGB values as all HEX variables have been replaced.

**What did not change:**

- Color configurations still accept HEX colors.
- Basic usage of the `color()` function in CSS properties will continue to work as expected.

Except the extremely rare cases where the usage of `color()` entirely relies on its return value being a `var()` and/or HEX color value, these changes should be fully backwards compatible. From my experience, I never encountered such cases in Whitecube's projects.